### PR TITLE
Fix corrupted vcxproj

### DIFF
--- a/blossom/blossom.vcxproj
+++ b/blossom/blossom.vcxproj
@@ -68,7 +68,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <CustomBuildBeforeTargets>Build</CustomBuildBeforeTargets>
   </PropertyGroup>
-  <PropertyGroup Label="Vcpkg">
+  <PropertyGroup Label="Vcpkg">
     <VcpkgEnabled>false</VcpkgEnabled>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">


### PR DESCRIPTION
Replace the non-breaking space on line 71 col 17, with a regular space.

When I load the project with VS2019, it didn't like the non-breaking space and wouldn't load