### PR TITLE
chore: add .gitignore, ignore stuff that should not be included in the version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.vs
+/blossom/out.html
+/blossom/Debug/
+/blossom/Release/
+/Debug/
+/Release/


### PR DESCRIPTION
This commit adds .gitignore, ignore stuff that should not be included in the version control.

Thought we might include `frag_draw.h` and `frag_present.h`, but it might not be a good idea, since we might do the "Heavy Release" procedure to shove extra bytes by modifying the minified shader code by hand, and we might want to preserve the hand-minified code in the version control